### PR TITLE
:speech_balloon: Clean outputs file debug

### DIFF
--- a/src/my_ai.rs
+++ b/src/my_ai.rs
@@ -1,10 +1,17 @@
 use crate::my_board::{MyBoard, Status};
-use std::io;
+use std::io::Write;
+use std::process;
+use std::{fs::File, io};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MyAI {
     pub my_board: MyBoard,
     pub begin: bool,
+
+    #[cfg(debug_assertions)]
+    pub input_file: File,
+    #[cfg(debug_assertions)]
+    pub output_file: File,
 }
 
 enum LogType {
@@ -27,9 +34,23 @@ impl LogType {
 
 impl MyAI {
     pub fn new() -> Self {
+        let pid = process::id();
+
+        #[cfg(debug_assertions)]
+        let input_file = File::create(format!("input_{}.txt", pid))
+            .expect("Failed to create input file in debug mode");
+        #[cfg(debug_assertions)]
+        let output_file = File::create(format!("output_{}.txt", pid))
+            .expect("Failed to create output file in debug mode");
+
         MyAI {
             my_board: MyBoard::new(),
             begin: true,
+
+            #[cfg(debug_assertions)]
+            input_file,
+            #[cfg(debug_assertions)]
+            output_file,
         }
     }
 
@@ -172,6 +193,9 @@ impl MyAI {
             input.clear();
             let n = io::stdin().read_line(&mut input)?;
 
+            #[cfg(debug_assertions)]
+            self.write_to_input_file(&input);
+
             if n == 0 {
                 break;
             }
@@ -181,5 +205,15 @@ impl MyAI {
             }
         }
         Ok(())
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn write_to_input_file(&mut self, mes: &str) {
+        let _res = write!(self.input_file, "{}", mes);
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn write_to_output_file(&mut self, mes: &str) {
+        let _res = write!(self.output_file, "{}", mes);
     }
 }

--- a/src/my_ai.rs
+++ b/src/my_ai.rs
@@ -193,7 +193,6 @@ impl MyAI {
             input.clear();
             let n = io::stdin().read_line(&mut input)?;
 
-            #[cfg(debug_assertions)]
             self.write_to_input_file(&input);
 
             if n == 0 {
@@ -207,13 +206,13 @@ impl MyAI {
         Ok(())
     }
 
-    #[cfg(debug_assertions)]
     pub fn write_to_input_file(&mut self, mes: &str) {
+        #[cfg(debug_assertions)]
         let _res = write!(self.input_file, "{}", mes);
     }
 
-    #[cfg(debug_assertions)]
     pub fn write_to_output_file(&mut self, mes: &str) {
+        #[cfg(debug_assertions)]
         let _res = write!(self.output_file, "{}", mes);
     }
 }


### PR DESCRIPTION
This pull requests implements functions to write into files. This is needed because `liskvork` capture all the output the programs do.

I create file handler in the AI struct and implemented functions to write to 2 files : `input_<pid>.txt` and `ouput_<pid>.txt`.

Those functions and file handler in the AI struct are compiled only when building in `debug` mode. It means that when you compile with `cargo build --release` it will not be compiled. This is useful because we do not wish to have those debug functionalities in our final program.