### PR TITLE
:green_heart: Added push_mirror dependency to run_tests

### DIFF
--- a/.github/workflows/gomoku.yaml
+++ b/.github/workflows/gomoku.yaml
@@ -51,7 +51,7 @@ jobs:
 
 
   push_to_mirror:
-    needs: [check_program_compilation]
+    needs: [run_tests]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This pull requests fixes the `push_to_mirror` step that was validated before the `run_tests` step ended.